### PR TITLE
Add waypoint depth entry

### DIFF
--- a/Lake Mapper/ContentView.swift
+++ b/Lake Mapper/ContentView.swift
@@ -1,21 +1,43 @@
-//
-//  ContentView.swift
-//  Lake Mapper
-//
-//  Created by Jonathan Miron on 2025-07-12.
-//
-
 import SwiftUI
+import MapKit
 
 struct ContentView: View {
+    @State private var waypoints: [Waypoint] = []
+    @State private var latText = ""
+    @State private var lonText = ""
+    @State private var depthText = ""
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 0) {
+            MapView(waypoints: $waypoints)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Form {
+                Section(header: Text("Add Waypoint")) {
+                    TextField("Latitude", text: $latText)
+                        .keyboardType(.decimalPad)
+                    TextField("Longitude", text: $lonText)
+                        .keyboardType(.decimalPad)
+                    TextField("Depth (m)", text: $depthText)
+                        .keyboardType(.decimalPad)
+                    Button("Add") {
+                        addWaypoint()
+                    }
+                }
+            }
+            .frame(maxHeight: 220)
         }
-        .padding()
+    }
+
+    private func addWaypoint() {
+        guard let lat = Double(latText),
+              let lon = Double(lonText),
+              let depth = Double(depthText) else { return }
+        let waypoint = Waypoint(coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon), depth: depth)
+        waypoints.append(waypoint)
+        latText = ""
+        lonText = ""
+        depthText = ""
     }
 }
 

--- a/Lake Mapper/MapView.swift
+++ b/Lake Mapper/MapView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    @Binding var waypoints: [Waypoint]
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 45.0, longitude: -90.0),
+        span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
+    )
+
+    var body: some View {
+        Map(coordinateRegion: $region, annotationItems: waypoints) { waypoint in
+            MapAnnotation(coordinate: waypoint.coordinate) {
+                VStack(spacing: 2) {
+                    Image(systemName: "mappin")
+                        .foregroundColor(.red)
+                    Text(String(format: "%.1f m", waypoint.depth))
+                        .font(.caption2)
+                        .padding(2)
+                        .background(Color.white.opacity(0.8))
+                        .cornerRadius(3)
+                }
+            }
+        }
+        .edgesIgnoringSafeArea(.all)
+    }
+}

--- a/Lake Mapper/Waypoint.swift
+++ b/Lake Mapper/Waypoint.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreLocation
+
+struct Waypoint: Identifiable {
+    let id = UUID()
+    let coordinate: CLLocationCoordinate2D
+    let depth: Double
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Lake Mapper
+
+Lake Mapper is a simple SwiftUI app for mapping lake depths. It lets you add waypoints with depth information and visualise them on a map.
+
+## Usage
+
+1. Enter the latitude, longitude and depth for a waypoint in the form at the bottom of the screen.
+2. Tap **Add** to place a marker on the map.
+3. Each marker displays the entered depth in metres.
+
+This demo uses `MapKit` for displaying the map but it can be adapted to use the Google Maps SDK if desired.


### PR DESCRIPTION
## Summary
- show a map with markers for saved waypoints
- allow entering latitude/longitude/depth to add a waypoint
- document the demo

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6872d41781c88323855f0b44df984e36