### PR TITLE
Add waypoint management screen and fix map centering

### DIFF
--- a/Lake Mapper/ContentView.swift
+++ b/Lake Mapper/ContentView.swift
@@ -3,6 +3,8 @@ import MapKit
 import Combine
 
 struct ContentView: View {
+    enum ViewMode { case map, waypoints }
+
     @State private var waypoints: [Waypoint] = []
     @State private var latText = ""
     @State private var lonText = ""
@@ -13,56 +15,79 @@ struct ContentView: View {
         span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
     )
     @State private var showCoords = false
+    @State private var hasCenteredOnUser = false
+    @State private var viewMode: ViewMode = .map
     @StateObject private var locationManager = LocationManager()
 
     var body: some View {
-        VStack(spacing: 0) {
-            ZStack(alignment: .topTrailing) {
-                MapView(waypoints: $waypoints, region: $region) { coord in
-                    latText = String(format: "%.6f", coord.latitude)
-                    lonText = String(format: "%.6f", coord.longitude)
-                }
-                Button(action: { showCoords = true }) {
-                    Image(systemName: "plus")
-                        .padding(8)
-                        .background(Color.white.opacity(0.8))
-                        .clipShape(Circle())
-                }
-                .padding()
-                .alert("Current Location", isPresented: $showCoords) {
-                    Button("OK", role: .cancel) {}
-                } message: {
-                    if let loc = locationManager.location {
-                        Text(String(format: "%.6f, %.6f", loc.coordinate.latitude, loc.coordinate.longitude))
-                    } else {
-                        Text("Location unavailable")
-                    }
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        NavigationView {
+            Group {
+                if viewMode == .map {
+                    VStack(spacing: 0) {
+                        ZStack(alignment: .topTrailing) {
+                            MapView(waypoints: $waypoints, region: $region) { coord in
+                                addWaypoint(at: coord)
+                            }
+                            Button(action: { showCoords = true }) {
+                                Image(systemName: "plus")
+                                    .padding(8)
+                                    .background(Color.white.opacity(0.8))
+                                    .clipShape(Circle())
+                            }
+                            .padding()
+                            .alert("Current Location", isPresented: $showCoords) {
+                                Button("OK", role: .cancel) {}
+                            } message: {
+                                if let loc = locationManager.location {
+                                    Text(String(format: "%.6f, %.6f", loc.coordinate.latitude, loc.coordinate.longitude))
+                                } else {
+                                    Text("Location unavailable")
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            Form {
-                Section(header: Text("Add Waypoint")) {
-                    TextField("Latitude", text: $latText)
-                        .keyboardType(.decimalPad)
-                    TextField("Longitude", text: $lonText)
-                        .keyboardType(.decimalPad)
-                    TextField("Depth (\(useFeet ? "ft" : "m"))", text: $depthText)
-                        .keyboardType(.decimalPad)
-                    Toggle("Use Feet", isOn: $useFeet)
-                    Button("Add") {
-                        addWaypoint()
+                        Form {
+                            Section(header: Text("Add Waypoint")) {
+                                TextField("Latitude", text: $latText)
+                                    .keyboardType(.decimalPad)
+                                TextField("Longitude", text: $lonText)
+                                    .keyboardType(.decimalPad)
+                                TextField("Depth (\(useFeet ? "ft" : "m"))", text: $depthText)
+                                    .keyboardType(.decimalPad)
+                                Toggle("Use Feet", isOn: $useFeet)
+                                Button("Add") {
+                                    addWaypointFromForm()
+                                }
+                            }
+                        }
+                        .frame(maxHeight: 220)
+                    }
+                } else {
+                    WaypointListView(waypoints: $waypoints)
+                }
+            }
+            .navigationTitle("Lake Mapper")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Menu {
+                        Button("Map View") { viewMode = .map }
+                        Button("Waypoints") { viewMode = .waypoints }
+                    } label: {
+                        Image(systemName: "line.3.horizontal")
                     }
                 }
             }
-            .frame(maxHeight: 220)
         }
         .onReceive(locationManager.$location.compactMap { $0 }) { loc in
-            region.center = loc.coordinate
+            if !hasCenteredOnUser {
+                region.center = loc.coordinate
+                hasCenteredOnUser = true
+            }
         }
     }
 
-    private func addWaypoint() {
+    private func addWaypointFromForm() {
         guard let lat = Double(latText),
               let lon = Double(lonText),
               let depth = Double(depthText) else { return }
@@ -72,6 +97,10 @@ struct ContentView: View {
         latText = ""
         lonText = ""
         depthText = ""
+    }
+
+    private func addWaypoint(at coord: CLLocationCoordinate2D) {
+        waypoints.append(Waypoint(coordinate: coord, depth: 0))
     }
 }
 

--- a/Lake Mapper/WaypointListView.swift
+++ b/Lake Mapper/WaypointListView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import MapKit
+
+struct WaypointListView: View {
+    @Binding var waypoints: [Waypoint]
+
+    var body: some View {
+        List {
+            ForEach($waypoints) { $waypoint in
+                NavigationLink(destination: EditWaypointView(waypoint: $waypoint)) {
+                    VStack(alignment: .leading) {
+                        Text(String(format: "%.6f, %.6f", waypoint.coordinate.latitude, waypoint.coordinate.longitude))
+                        Text(String(format: "Depth: %.1f m", waypoint.depth))
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .onDelete { indices in
+                waypoints.remove(atOffsets: indices)
+            }
+        }
+    }
+}
+
+struct EditWaypointView: View {
+    @Binding var waypoint: Waypoint
+    @Environment(\.dismiss) private var dismiss
+    @State private var latText: String
+    @State private var lonText: String
+    @State private var depthText: String
+
+    init(waypoint: Binding<Waypoint>) {
+        _waypoint = waypoint
+        _latText = State(initialValue: String(format: "%.6f", waypoint.wrappedValue.coordinate.latitude))
+        _lonText = State(initialValue: String(format: "%.6f", waypoint.wrappedValue.coordinate.longitude))
+        _depthText = State(initialValue: String(format: "%.1f", waypoint.wrappedValue.depth))
+    }
+
+    var body: some View {
+        Form {
+            TextField("Latitude", text: $latText)
+                .keyboardType(.decimalPad)
+            TextField("Longitude", text: $lonText)
+                .keyboardType(.decimalPad)
+            TextField("Depth (m)", text: $depthText)
+                .keyboardType(.decimalPad)
+            Button("Save") {
+                if let lat = Double(latText), let lon = Double(lonText), let depth = Double(depthText) {
+                    waypoint.coordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+                    waypoint.depth = depth
+                    dismiss()
+                }
+            }
+        }
+        .navigationTitle("Edit Waypoint")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Lake Mapper
 
-Lake Mapper is a simple SwiftUI app for mapping lake depths. It lets you add waypoints with depth information and visualise them on a map.
+Lake Mapper is a simple SwiftUI app for mapping lake depths. It lets you drop waypoints on a map and edit them later in a list view.
 
 ## Usage
 
-1. Enter the latitude, longitude and depth for a waypoint in the form at the bottom of the screen.
-2. Tap **Add** to place a marker on the map.
-3. Each marker displays the entered depth in metres.
+1. Long‑press on the map to drop a waypoint or use the form to enter exact coordinates and depth.
+2. Switch between the map and the list of waypoints using the menu button.
+3. In the list view you can edit or delete each waypoint.
+4. Each marker displays the entered depth in metres.
 
 This demo uses `MapKit` for displaying the map but it can be adapted to use the Google Maps SDK if desired.


### PR DESCRIPTION
## Summary
- fix map recentering by only using the user's location once
- allow long‑press to drop a new waypoint on the map
- provide a menu to switch between map and waypoint list views
- add editing and deleting waypoints in the new list view
- document the new behaviour

## Testing
- `swiftc -typecheck 'Lake Mapper'/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6872e28a3ba08323b0136c8de06aabf8