### PR TITLE
Fix heatmap renderer max/min naming

### DIFF
--- a/Lake Mapper/HeatmapOverlay.swift
+++ b/Lake Mapper/HeatmapOverlay.swift
@@ -24,7 +24,7 @@ class DepthHeatmapRenderer: MKOverlayRenderer {
         for waypoint in overlayData.waypoints {
             let point = self.point(for: MKMapPoint(waypoint.coordinate))
             let radius = max(30.0, waypoint.depth * 5.0) / zoomScale
-            let color = DepthHeatmapRenderer.color(for: waypoint.depth, min: minDepth, max: maxDepth)
+            let color = DepthHeatmapRenderer.color(for: waypoint.depth, minDepth: minDepth, maxDepth: maxDepth)
             let cgColor = color.cgColor
             let colors: [CGColor] = [cgColor.copy(alpha: 0.6)!, cgColor.copy(alpha: 0.0)!]
             if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: colors as CFArray, locations: [0, 1]) {
@@ -38,8 +38,8 @@ class DepthHeatmapRenderer: MKOverlayRenderer {
         }
     }
 
-    static func color(for depth: Double, min: Double, max: Double) -> UIColor {
-        let normalized = max(0, min( (depth - min) / max(max - min, 0.0001), 1 ))
+    static func color(for depth: Double, minDepth: Double, maxDepth: Double) -> UIColor {
+        let normalized = Swift.max(0, Swift.min( (depth - minDepth) / Swift.max(maxDepth - minDepth, 0.0001), 1 ))
         return UIColor(hue: 0.6, saturation: 1.0, brightness: 1.0 - CGFloat(normalized) * 0.6, alpha: 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- fix parameter naming in `DepthHeatmapRenderer.color()` to avoid collision with Swift's `min`/`max`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6872f27a9bf48323b6466eb4d6d68afc